### PR TITLE
Fix compilation error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ except ImportError:
 if not sys.platform == "win32":
     # suppress warnings for importing numpy
     CARGS.append("-Wno-unused-function")
+    # suppress errors for narrowing
+    CARGS.append("-Wno-narrowing")
 
 extensions = [
     Extension("geodesy.sphere",


### PR DESCRIPTION
Had an error with installation on Linux (see below), my addition of `-Wno-narrowing` compilation flag fixes it.

> $ pip install -e git+https://github.com/xoolive/geodesy.git#egg=geodesy
> Obtaining geodesy from git+https://github.com/xoolive/geodesy.git#egg=geodesy
>   Updating ./venv/src/geodesy clone
> Installing collected packages: geodesy
>   Running setup.py develop for geodesy
>     Complete output from command /home/luke/Programowanie/Python/LocalizeFriends/backend/venv/bin/python3 -c "import setuptools, tokenize;__file__='/home/luke/Programowanie/Python/LocalizeFriends/backend/venv/src/geodesy/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" develop --no-deps:
>     running develop
>     running egg_info
>     writing geodesy.egg-info/PKG-INFO
>     writing dependency_links to geodesy.egg-info/dependency_links.txt
>     writing top-level names to geodesy.egg-info/top_level.txt
>     reading manifest file 'geodesy.egg-info/SOURCES.txt'
>     writing manifest file 'geodesy.egg-info/SOURCES.txt'
>     running build_ext
>     building 'geodesy.sphere' extension
>     creating build
>     creating build/temp.linux-x86_64-3.6
>     creating build/temp.linux-x86_64-3.6/geodesy
>     gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -fPIC -I/home/luke/Programowanie/Python/LocalizeFriends/backend/venv/lib/python3.6/site-packages/numpy/core/include -I/usr/include/python3.6m -c geodesy/sphere.cpp -o build/temp.linux-x86_64-3.6/geodesy/sphere.o -Wno-unused-function
>     cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++

>     In file included from geodesy/sphere.cpp:472:0:
>     geodesy/../src/spherical_geodesy.h:54:44: warning: ignoring attributes on template argument ‘__m128 {aka __vector(4) float}’ [-Wignored-attributes]
>        template<> __m128 SphericalGeodesy<__m128>::EarthRadius =
>                             
>     geodesy/../src/sse2_math.h:114:68: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
>      static const __m128d _mm_cst_pd_sincof_p4 = _mm_set1_pd(*(double*) sincof4);
>                                                                         ^~~~~~~

>     geodesy/../src/sse2_math.h:144:68: error: narrowing conversion of ‘51019’ from ‘int’ to ‘short int’ inside { } [-Wnarrowing]
>      static const short asincof_p2[] = { 0x2dd9, 0x178a, 0xc74b, 0x4015 };
>                                                                         ^
>     geodesy/../src/sse2_math.h:169:68: error: narrowing conversion of ‘40712’ from ‘int’ to ‘short int’ inside { } [-Wnarrowing]
>      static const short asincof_r0[] = { 0x9f08, 0x988e, 0x4fc3, 0x3f68 };
>                                                                         ^
>     geodesy/../src/spherical_geodesy.hpp:404:32: warning: ignoring attributes on template argument ‘__m128 {aka __vector(4) float}’ [-Wignored-attributes]
>              SphericalGeodesy<__m128>::destination(
>                                     ^
>     error: command 'gcc' failed with exit status 1
>     
> [shortened]